### PR TITLE
Fix for Gnome 3.30+

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,20 +6,29 @@ const Shell = imports.gi.Shell;
 const GLib = imports.gi.GLib;
 const PopupMenu = imports.ui.popupMenu;
 const Gettext = imports.gettext;
-
 const _ = Gettext.gettext;
 
 let item, userMenu;
 
+function _getUserMenu() {
+    if (Main.panel._statusArea) {
+        return Main.panel._statusArea.userMenu.menu;
+    } else if (Main.panel.statusArea.userMenu) {
+        return Main.panel.statusArea.userMenu.menu;
+    } else {
+        return Main.panel.statusArea.aggregateMenu.menu;
+    }
+}
+
 function _onAdvancedSettingsActivate() {
     Main.overview.hide();
-    let app = Shell.AppSystem.get_default().lookup_app('gnome-tweak-tool.desktop');
+    let app = Shell.AppSystem.get_default().lookup_app('org.gnome.tweaks.desktop');
     app.activate();
 }
 
 function init(extensionMeta) {
     Gettext.bindtextdomain("advanced-settings-in-usermenu@nuware.ru", GLib.build_filenamev([extensionMeta.path, 'locale']));
-    userMenu = Main.panel._statusArea.userMenu.menu;
+    userMenu = _getUserMenu();
 }
 
 function enable() {

--- a/metadata.json
+++ b/metadata.json
@@ -4,11 +4,12 @@
   "name": "Advanced Settings in UserMenu",
   "original-author": "dima.dudin@gmail.com",
   "shell-version": [
+    "3.30",
     "3.2",
     "3.2.1",
     "3.2.2"
   ],
   "url": "http://github.com/outbreak/advanced-settings-in-usermenu",
   "uuid": "advanced-settings-in-usermenu@nuware.ru",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
Changes, so that the extension works with Gnome 3.30 and maybe earlier versions. Though I think I broke the localization.